### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A TCP port traffic monitor written in Python.
 
-[![Latest Version](https://pypip.in/version/tcpstat/badge.svg?text=pypi)](https://pypi.python.org/pypi/tcpstat/)
-[![Downloads](https://pypip.in/download/tcpstat/badge.svg)](https://pypi.python.org/pypi/tcpstat/)
+[![Latest Version](https://img.shields.io/pypi/v/tcpstat.svg?label=pypi)](https://pypi.python.org/pypi/tcpstat/)
+[![Downloads](https://img.shields.io/pypi/dm/tcpstat.svg
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/caizixian/tcpstat/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/caizixian/tcpstat/?branch=master)
 
 ## Dependencies:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 A TCP port traffic monitor written in Python.
 
 [![Latest Version](https://img.shields.io/pypi/v/tcpstat.svg?label=pypi)](https://pypi.python.org/pypi/tcpstat/)
-[![Downloads](https://img.shields.io/pypi/dm/tcpstat.svg
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/caizixian/tcpstat/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/caizixian/tcpstat/?branch=master)
 
 ## Dependencies:


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20tcpstat))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `tcpstat`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.